### PR TITLE
Use the keyring module if available to store the password

### DIFF
--- a/src/USER_DATA/utils/assignment_uploader.py
+++ b/src/USER_DATA/utils/assignment_uploader.py
@@ -17,6 +17,10 @@ from os.path import join, basename
 import tarfile
 import requests
 import getpass
+try:
+    import keyring
+except ImportError:
+    keyring = False
 
 
 def get_ssl_cert():
@@ -28,13 +32,16 @@ def get_ssl_cert():
     else:
         return False
 
-
+    
 def get_user_and_pass():
-    auth_data = {
-        'username': raw_input("Please provide a STAFF account email: "),
-        'password': getpass.getpass('Password: '),
-    }
-    return auth_data
+    username = raw_input("Please provide a STAFF account email: ")
+    password = None
+    if keyring:
+        password = keyring.get_password("DataAnalysis", username)
+    if password is None:
+        password = getpass.getpass('Password: ')
+    return {'username': username,
+            'password': password}
 
 
 def make_tarfile(output_filename, source_dir):

--- a/src/USER_DATA/utils/submit.py
+++ b/src/USER_DATA/utils/submit.py
@@ -10,6 +10,10 @@ from os import remove
 import tarfile
 import requests
 import getpass
+try:
+    import keyring
+except ImportError:
+    keyring = False
 import sys
 from subprocess import Popen, PIPE, STDOUT
 
@@ -37,12 +41,15 @@ def get_ssl_cert():
 
 
 def get_user_and_pass():
-    auth_data = {
-        'username': raw_input("Enter email: "),
-        'password': getpass.getpass('Password: '),
-        'submit_key': SUBMIT_KEY
-    }
-    return auth_data
+    username = raw_input("Enter email: ")
+    password = None
+    if keyring:
+        password = keyring.get_password("DataAnalysis", username)
+    if password is None:
+        password = getpass.getpass('Password: ')
+    return {'username': username,
+            'password': password,
+            'submit_key': SUBMIT_KEY}
 
 
 def create_package(file_list, out):


### PR DESCRIPTION
Install the keyring module from https://pypi.python.org/pypi/keyring using

`pip install keyring`

Store the TeaRoom password in the keyring:

`python -m keyring set DataAnalysis <username>`

The `DataAnalysis` part is currently a magic constant.

Afterwards you only have to enter the username and the password will be taken from keyring if it exists.

The following keyring backends are supported by the Python keyring lib:

    Mac OS X Keychain
    Freedesktop Secret Service (requires secretstorage)
    KWallet (requires dbus)
    Windows Credential Vault

So it should allow usage by all major operating systems.